### PR TITLE
Send special characters in Qwerty controller using <Char> notation

### DIFF
--- a/js-dos-ts/controller/qwerty.ts
+++ b/js-dos-ts/controller/qwerty.ts
@@ -39,8 +39,8 @@ function convert(input: string): string
     while (i < input.length) {
         if (input[i] === '<') {
             let index: number = controlChars.findIndex((key: any) => {
-                return input.substr(i+1, key.name.length).toLowerCase()
-                    === key.name.toLowerCase();
+                return input.substr(i+1, key.name.length+1).toLowerCase()
+                    === key.name.toLowerCase() + '>';
             });
             if (index !== -1) {
                 output += String.fromCharCode(controlChars[index].code);

--- a/js-dos-ts/controller/qwerty.ts
+++ b/js-dos-ts/controller/qwerty.ts
@@ -10,6 +10,54 @@ const defaultOptions: QwertyOptions = {
     uppercase: true,
 };
 
+function convert(input: string): string
+{
+    let controlChars: any[] = [
+        { name: 'Backspace', code: 8 },
+        { name: 'Tab',       code: 9 },
+        { name: 'Enter',     code: 13 },
+        { name: 'Shift',     code: 16 },
+        { name: 'Ctrl',      code: 17 },
+        { name: 'Alt',       code: 18 },
+        { name: 'Pause',     code: 19 },
+        { name: 'Caps',      code: 20 },
+        { name: 'Esc',       code: 27 },
+        { name: 'PgUp',      code: 33 },
+        { name: 'PgDn',      code: 34 },
+        { name: 'End',       code: 35 },
+        { name: 'Home',      code: 36 },
+        { name: 'Left',      code: 37 },
+        { name: 'Up',        code: 38 },
+        { name: 'Right',     code: 39 },
+        { name: 'Down',      code: 40 },
+        { name: 'Insert',    code: 45 },
+        { name: 'Delete',    code: 46 },
+    ];
+
+    let i: number = 0;
+    let output: string = '';
+    while (i < input.length) {
+        if (input[i] === '<') {
+            let index: number = controlChars.findIndex((key: any) => {
+                return input.substr(i+1, key.name.length).toLowerCase()
+                    === key.name.toLowerCase();
+            });
+            if (index !== -1) {
+                output += String.fromCharCode(controlChars[index].code);
+                i += controlChars[index].name.length + 2;
+            } else {
+                output += input[i];
+                i++;
+            }
+        } else {
+            output += input[i];
+            i++;
+        }
+    }
+
+    return output;
+}
+
 export default function Qwerty(zone: HTMLDivElement, consumer: DosKeyEventConsumer,
                                options: QwertyOptions = defaultOptions) {
     DosDom.applyCss("lqwerty-css", css + "\n\n" + (options.cssText || ""));
@@ -25,16 +73,18 @@ export default function Qwerty(zone: HTMLDivElement, consumer: DosKeyEventConsum
         }
 
         let i = 0;
+        let convertedValue: string = convert(value);
+
         const id = setInterval(() => {
-            if (i >= value.length * 2) {
+            if (i >= convertedValue.length * 2) {
                 clearInterval(id);
                 return;
             }
 
             if (i % 2 === 0) {
-                consumer.onPress(value.charCodeAt(i / 2));
+                consumer.onPress(convertedValue.charCodeAt(i / 2));
             } else {
-                consumer.onRelease(value.charCodeAt((i - 1) / 2));
+                consumer.onRelease(convertedValue.charCodeAt((i - 1) / 2));
             }
             i++;
         }, 100);


### PR DESCRIPTION
Currently there is no way for the user on mobile devices to enter special characters using the Qwerty controller. This PR enables entering some special characters using the notation `<Char_name>`. The following `Char_name`s are supported:

| Char_name | Code |
|-----------|------|
| Backspace | 8    |
| Tab       | 9    |
| Enter     | 13   |
| Shift     | 16   |
| Ctrl      | 17   |
| Alt       | 18   |
| Pause     | 19   |
| Caps      | 20   |
| Esc       | 27   |
| PgUp      | 33   |
| PgDn      | 34   |
| End       | 35   |
| Home      | 36   |
| Left      | 37   |
| Up        | 38   |
| Right     | 39   |
| Down      | 40   |
| Insert    | 45   |
| Delete    | 46   |

For example, you can use

```
<Esc><Up><Enter>Y
```

to send the characters with character codes `27`, `38`, `13`, `89` to the program.
