### PR TITLE
Fix some non-fatal ts errors

### DIFF
--- a/js-dos-ts/js-dos-ci.ts
+++ b/js-dos-ts/js-dos-ci.ts
@@ -13,7 +13,7 @@ export class DosCommandInterface {
     private onready: (ci: DosCommandInterface) => void;
 
     private shellInputQueue: string[] = [];
-    private shellInputClients: Array<() => void> = [];
+    private shellInputClients: Array<(value?: unknown) => void> = [];
     private onstdout?: (data: string) => void = undefined;
     private keyEventConsumer: DosKeyEventConsumer = {
         onPress: (keyCode) => this.simulateKeyEvent(keyCode, true),

--- a/js-dos-ts/js-dos-fs.ts
+++ b/js-dos-ts/js-dos-fs.ts
@@ -224,6 +224,7 @@ export class DosFS {
         }
 
         this.syncingPromise = new Promise<void>((resolve, reject) => {
+            // @ts-ignore the unusued local for startedAt not being read
             const startedAt = Date.now();
             this.fs.syncfs(false, (err: any) => {
                 if (err) {

--- a/js-dos-ts/js-dos-host.ts
+++ b/js-dos-ts/js-dos-host.ts
@@ -143,6 +143,7 @@ class DosHost {
     private compileJsDosBox(url: string, cache: ICache, module: DosModule): Promise<any> {
         return new Promise((resolve, reject) => {
             const buildTotal = Build.jsSize;
+            // @ts-ignore the unusued local for memUrl not being read
             const memUrl = url.replace(".js", ".js.mem");
 
             // * Host download `dosbox.js`

--- a/js-dos-ts/js-dos-module.ts
+++ b/js-dos-ts/js-dos-module.ts
@@ -1,6 +1,7 @@
 // # DosModule
 // DosModule is [emscripten module object](https://kripken.github.io/emscripten-site/docs/api_reference/module.html),
 // with additional functionality
+// @ts-ignore the unusued local for Dos not being used
 import Dos, { DosRuntime } from "./js-dos";
 import { Build } from "./js-dos-build";
 import { DosCommandInterface } from "./js-dos-ci";
@@ -16,6 +17,7 @@ export class DosModule extends DosOptions {
     public onglobals?: (...args: any[]) => void;
     public ci: Promise<DosCommandInterface>;
 
+    // @ts-ignore the unusued local for instance not being read
     private instance: any;
     private fs: DosFS | null = null;
     private ui: DosUi | null = null;
@@ -41,6 +43,7 @@ export class DosModule extends DosOptions {
 
     private registerDefaultListeners() {
         let hidden: string;
+        // @ts-ignore the unusued local for visibilityChange not being read
         let visibilityChange: string;
 
         if (typeof document.hidden !== "undefined") {


### PR DESCRIPTION
This fixes a few errors that show up in more restrictive typescript compilation environments, specifically when type checking the promise array and when noUnusedLocales is set to true.

From what I could tell, the errors are real, in that the variables are assigned but not read from, etc.  But, I've taken the less invasive approach of marking the specific errors as ignored, since I didn't know if they were reserved for future uses.
