### PR TITLE
Add pointerup/cancel events to element in addition to window.

### DIFF
--- a/src/components/horizontal-slider.ts
+++ b/src/components/horizontal-slider.ts
@@ -74,6 +74,8 @@ export function HorizontalSlider(props: HorizontalSliderProps) {
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", onEnd);
         window.addEventListener("pointercancel", onEnd);
+        el.addEventListener("pointerup", onEnd);
+        el.addEventListener("pointercancel", onEnd);
         props.registerListner(setValue);
 
         return () => {

--- a/src/components/horizontal-slider.ts
+++ b/src/components/horizontal-slider.ts
@@ -84,6 +84,8 @@ export function HorizontalSlider(props: HorizontalSliderProps) {
             window.removeEventListener("pointermove", onMove);
             window.removeEventListener("pointerup", onEnd);
             window.removeEventListener("pointercancel", onEnd);
+            el.removeEventListener("pointerup", onEnd);
+            el.removeEventListener("pointercancel", onEnd);
         };
     }, [sliderRef]);
 

--- a/src/components/vertical-slider.ts
+++ b/src/components/vertical-slider.ts
@@ -73,6 +73,8 @@ export function VerticalSlider(props: VerticalSliderProps) {
         window.addEventListener("pointermove", onMove);
         window.addEventListener("pointerup", onEnd);
         window.addEventListener("pointercancel", onEnd);
+        el.addEventListener("pointerup", onEnd);
+        el.addEventListener("pointercancel", onEnd);
         props.registerListner(setValue);
 
         return () => {

--- a/src/components/vertical-slider.ts
+++ b/src/components/vertical-slider.ts
@@ -83,6 +83,8 @@ export function VerticalSlider(props: VerticalSliderProps) {
             window.removeEventListener("pointermove", onMove);
             window.removeEventListener("pointerup", onEnd);
             window.removeEventListener("pointercancel", onEnd);
+            el.removeEventListener("pointerup", onEnd);
+            el.removeEventListener("pointercancel", onEnd);
         };
     }, [sliderRef]);
 


### PR DESCRIPTION
The slider components (both horizontal and vertical) are having a bug in Chrome (desktop) where the `pointerup` and `pointercancel` events never get fired, possibly because the `pointerdown` event gets consumed by the browser and/or emulator (?) incorrectly.
This causes the sliders to keep reacting to `pointermove` events, even when the pointer has moved away from the slider, with no way to cancel the movement.

This PR explicitly adds `pointerup` and `cancel` events to the slider element itself (in addition to the existing events), to make sure that the pointer movement will be cancelled.